### PR TITLE
Refactor the repo_mapping variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [1.2.0-alpha.2](https://github.com/fabidick22/flux2-ecr-webhook/compare/v1.2.0-alpha.1...v1.2.0-alpha.2) (2023-07-06)
+
+### Code Refactoring
+
+- Add info logs ([2602f32](https://github.com/fabidick22/flux2-ecr-webhook/commit/2602f3275c3ba3fa7b057c38cb7ea625777f47a3))
+
 # [1.2.0-alpha.1](https://github.com/fabidick22/flux2-ecr-webhook/compare/v1.1.0...v1.2.0-alpha.1) (2023-07-05)
 
 ### Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [1.2.0-alpha.3](https://github.com/fabidick22/flux2-ecr-webhook/compare/v1.2.0-alpha.2...v1.2.0-alpha.3) (2023-07-12)
+
+### Documentation
+
+- Update docs about refactoring the repo_mapping variable ([ffc4f5c](https://github.com/fabidick22/flux2-ecr-webhook/commit/ffc4f5cf4a1b4be4b593b9a34742e0c9d863b2e2))
+
 # [1.2.0-alpha.2](https://github.com/fabidick22/flux2-ecr-webhook/compare/v1.2.0-alpha.1...v1.2.0-alpha.2) (2023-07-06)
 
 ### Code Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# [1.2.0-alpha.1](https://github.com/fabidick22/flux2-ecr-webhook/compare/v1.1.0...v1.2.0-alpha.1) (2023-07-05)
+
+### Chores
+
+- **release:** v1.1.1 ([b101b29](https://github.com/fabidick22/flux2-ecr-webhook/commit/b101b29a74b192f0aeb2347fd761ff7b26b78ef5))
+
+### Continuous Integration
+
+- Update trigger branchs (#8) ([8d2b843](https://github.com/fabidick22/flux2-ecr-webhook/commit/8d2b843603409d66f5aff1549997d89063f88c46)), closes [#8](https://github.com/fabidick22/flux2-ecr-webhook/issues/8)
+
+### Documentation
+
+- Update TODO list (#9) ([1df3d43](https://github.com/fabidick22/flux2-ecr-webhook/commit/1df3d4380852c25ceb4648ea2eeddafe105f4df7)), closes [#9](https://github.com/fabidick22/flux2-ecr-webhook/issues/9)
+
+### Features
+
+- Add support for a regex parameter \n\n BREAKING CHANGE: Update repo_mapping variable to support the regex attribute ([4f165d0](https://github.com/fabidick22/flux2-ecr-webhook/commit/4f165d041333ca8e2f9b0df49adaa3bf7ba0dc1f))
+
 ## [1.1.1](https://github.com/fabidick22/flux2-ecr-webhook/compare/v1.1.0...v1.1.1) (2023-07-04)
 
 ### Continuous Integration

--- a/README.md
+++ b/README.md
@@ -42,17 +42,28 @@ spec:
       name: my-ecr-repo-ir
 ```
 The webhook created by the `Receiver` resource has to be configured in the module, for example:
+> **Note**: Let's assume that our ECR repository is called `my-ecr-repo`.
+
 ```hcl
 module "flux2-ecr-webhook" {
-  source = "github.com/fabidick22/flux2-ecr-webhook?ref=v1.0.2"
+  source = "github.com/fabidick22/flux2-ecr-webhook?ref=v1.2.0"
 
-  ...
+  app_name = "flux-ecr-webhook"
+
   repo_mapping = {
-    my-ecr-repo = {
-      webhook = ["https://custom.domain.com/hook/11111111", "https://custom.domain.com/hook/2222222"]
+    my-ecr-repo = {                                    # ECR resource name
+      prod = {
+        webhook = ["https://domain.com/hook/1111111"]  # URL created by the Receiver
+        regex   = "prod-(?P<version>.*)"               # Regex for ECR image tag
+      }
+      stg = {
+        webhook = ["https://domain.com/hook/2222222"]  # URL created by the Receiver
+        regex   = "stg-(?P<version>.*)"                # Regex for ECR image tag
+      }
     }
   }
-  ...
+
+  webhook_token = "var.webhook_token"
 }
 ```
 ## Example
@@ -101,7 +112,7 @@ module "flux2-ecr-webhook" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name used for resources to create. | `string` | `"flux2-ecr-webhook"` | no |
 | <a name="input_cw_logs_retention"></a> [cw\_logs\_retention](#input\_cw\_logs\_retention) | Specifies the number of days you want to retain log events in the specified log group. | `number` | `14` | no |
-| <a name="input_repo_mapping"></a> [repo\_mapping](#input\_repo\_mapping) | Object with repository mapping, if this variable is set `repo_mapping_file` will be ignored.<br>**Example:**<pre>{<br>  ecr-repo-name = {<br>    webhook = ["https://gitops.domain.com/hook/111111" ]<br>  }<br>  test/ecr-repo-name = {<br>    webhook = ["https://gitops.domain.com/hook/111111", "https://gitops.domain.com/hook/222222" ]<br>    token = "webhook-token "<br>  }<br>}</pre> | `any` | `null` | no |
+| <a name="input_repo_mapping"></a> [repo\_mapping](#input\_repo\_mapping) | Object with repository mapping, if this variable is set `repo_mapping_file` will be ignored.<br><br>**Available Attributes:**<br>- `<ECR>`: ECR resource name.<br>- `<ECR>.<ID>`: Unique name for webhooks.<br>- `<ECR>.<ID>.webhook`: Webhook list.<br>- `<ECR>.<ID>.token` (Optional): Token used for webhooks, if set, then "webhook\_token" will be ignored.<br>- `<ECR>.<ID>.regex` (Optional): Regular expression that is applied to the image tag | `any` | `null` | no |
 | <a name="input_repo_mapping_file"></a> [repo\_mapping\_file](#input\_repo\_mapping\_file) | YAML file path with repository mapping. | `string` | `""` | no |
 | <a name="input_webhook_token"></a> [webhook\_token](#input\_webhook\_token) | Webhook default token used to call the Flux receiver. If it doesn't find a `token` attribute in the repository mapping use this token for the webhooks | `string` | `null` | no |
 

--- a/docs/tf-docs/header.md
+++ b/docs/tf-docs/header.md
@@ -42,17 +42,28 @@ spec:
       name: my-ecr-repo-ir
 ```
 The webhook created by the `Receiver` resource has to be configured in the module, for example:
+> **Note**: Let's assume that our ECR repository is called `my-ecr-repo`.
+
 ```hcl
 module "flux2-ecr-webhook" {
-  source = "github.com/fabidick22/flux2-ecr-webhook?ref=v1.0.2"
+  source = "github.com/fabidick22/flux2-ecr-webhook?ref=v1.2.0"
 
-  ...
+  app_name = "flux-ecr-webhook"
+
   repo_mapping = {
-    my-ecr-repo = {
-      webhook = ["https://custom.domain.com/hook/11111111", "https://custom.domain.com/hook/2222222"]
+    my-ecr-repo = {                                    # ECR resource name
+      prod = {
+        webhook = ["https://domain.com/hook/1111111"]  # URL created by the Receiver
+        regex   = "prod-(?P<version>.*)"               # Regex for ECR image tag
+      }
+      stg = {
+        webhook = ["https://domain.com/hook/2222222"]  # URL created by the Receiver
+        regex   = "stg-(?P<version>.*)"                # Regex for ECR image tag
+      }
     }
   }
-  ...
+
+  webhook_token = "var.webhook_token"
 }
 ```
 ## Example

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,20 +1,13 @@
 
-module "flux2-ecr-webhook" {
-  source = "../../"
-
-  app_name          = "flux2-ecr-webhook"
-  repo_mapping_file = "repos.yml" # Deprecated
-  webhook_token     = "WEBHOOK-TOKEN" # Keep this token safe, you can use sops (mozilla/sops).
-  cw_logs_retention = 7
-}
-
 module "flux2-ecr-webhook2" {
   source = "../../"
 
   app_name = "flux2-ecr-webhook2"
   repo_mapping = {
-    test/my-ecr-repo = {
-      webhook = "https://gitops.domain.com/hook/11111111111"
+    "test/my-ecr-repo" = {
+      production = {
+        webhook = ["https://gitops.domain.com/hook/11111111111"]
+      }
     }
   }
   webhook_token = "WEBHOOK-TOKEN" # Keep this token safe, you can use sops (mozilla/sops).
@@ -26,15 +19,22 @@ module "flux2-ecr-webhook3" {
   app_name = "flux2-ecr-webhook3"
   repo_mapping = {
     my-ecr-repo = {
-      webhook = "https://gitops.domain.com/hook/11111111111"
-      token = "WEBHOOK-TOKEN" # Keep this token safe, you can use sops (mozilla/sops).
+      prod = {
+        webhook = ["https://gitops.domain.com/hook/11111111111"]
+      }
     }
     my-ecr-repo2 = {
-      webhook = "https://gitops.domain.com/hook/11111111111"
+      prod = {
+        webhook = ["https://gitops.domain.com/hook/11111111111"]
+        regex   = "prod-(?P<version>.*)" # Regex for ECR image tag
+      }
     }
     my-ecr-repo3 = {
-      webhook = "https://gitops.domain.com/hook/11111111111"
+      prod = {
+        webhook = ["https://gitops.domain.com/hook/11111111111"]
+        token   = "WEBHOOK-TOKEN" # Custom token (you can use mozilla/sops).
+      }
     }
   }
-  webhook_token = "WEBHOOK-TOKEN" # Keep this token safe, you can use sops (mozilla/sops).
+  webhook_token = "WEBHOOK-TOKEN" # Webhook token (you can use mozilla/sops).
 }

--- a/src/call_receiver/app.py
+++ b/src/call_receiver/app.py
@@ -73,6 +73,11 @@ def call_flux_webhook(repository, image_tag):
                 headers = {'Authorization': f'Bearer {token}'}
                 if regex and re.match(regex, image_tag):
                     make_requests(webhook, repository, headers)
+                else:
+                    print(json.dumps({
+                        'message': f'The {image_tag} tag does not match the regular expresion ({regex})',
+                        'repository': repository
+                    }))
 
 
 def lambda_handler(event, context):

--- a/src/call_receiver/app.py
+++ b/src/call_receiver/app.py
@@ -2,6 +2,7 @@ import json
 import boto3
 import requests
 import os
+import re
 
 secretsmanager = boto3.client('secretsmanager')
 TOKEN_SECRET_NAME = os.environ['FLUX2_WEBHOOK_TOKEN_SECRET_NAME']
@@ -54,7 +55,8 @@ def make_requests(webhook_url, repository, headers):
             'repository': repository
         }))
 
-def call_flux_webhook(repository):
+
+def call_flux_webhook(repository, image_tag):
     # Retrieve the map of values from Secrets Manager
     webhook_map = get_webhook_map()
 
@@ -63,13 +65,14 @@ def call_flux_webhook(repository):
     token = None
     if repository in webhook_map:
         repo_data = webhook_map[repository]
-        webhook_urls = repo_data.get('webhook')
-        token = repo_data.get('token', get_global_token())
-        for webhook in webhook_urls:
-            headers = {'Authorization': f'Bearer {token}'}
-            make_requests(webhook, repository, headers)
-
-
+        for key, data in repo_data.items():
+            webhook_urls = data.get('webhook')
+            token = data.get('token', get_global_token())
+            regex = data.get('regex', '.*')
+            for webhook in webhook_urls:
+                headers = {'Authorization': f'Bearer {token}'}
+                if regex and re.match(regex, image_tag):
+                    make_requests(webhook, repository, headers)
 
 
 def lambda_handler(event, context):
@@ -82,7 +85,7 @@ def lambda_handler(event, context):
     process_ecr_push_event(detail)
 
     # Call the Flux webhook with the event repository
-    call_flux_webhook(detail['repository-name'])
+    call_flux_webhook(detail['repository-name'], detail['image-tag'])
 
     return {
         'statusCode': 200,

--- a/variables.tf
+++ b/variables.tf
@@ -14,22 +14,15 @@ variable "repo_mapping" {
   type        = any
   default     = null
   sensitive   = true
-  #description = "Object with repository mapping, if this variable is set `repo_mapping_file` will be ignored."
   description = <<EOT
 Object with repository mapping, if this variable is set `repo_mapping_file` will be ignored.
-**Example:**
 
-```
-{
-  ecr-repo-name = {
-    webhook = ["https://gitops.domain.com/hook/111111" ]
-  }
-  test/ecr-repo-name = {
-    webhook = ["https://gitops.domain.com/hook/111111", "https://gitops.domain.com/hook/222222" ]
-    token = "webhook-token "
-  }
-}
-```
+**Available Attributes:**
+- `<ECR>`: ECR resource name.
+- `<ECR>.<ID>`: Unique name for webhooks.
+- `<ECR>.<ID>.webhook`: Webhook list.
+- `<ECR>.<ID>.token` (Optional): Token used for webhooks, if set, then "webhook_token" will be ignored.
+- `<ECR>.<ID>.regex` (Optional): Regular expression that is applied to the image tag
 
 EOT
 }


### PR DESCRIPTION
Changes:
- Refactor the `repo_mapping` variable to allow more flexible configuration of webhooks, this is useful when you have a specific AWS account for all ECR repositories.