### PR TITLE
ci: add maintenance branch triggers to semver workflow

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -8,6 +8,8 @@ on:
       - alpha
       - next
       - next-major
+      - '[0-9]+.x'
+      - '[0-9]+.[0-9]+.x'
 
 jobs:
   release:


### PR DESCRIPTION
Add glob patterns '[0-9]+.x' and '[0-9]+.[0-9]+.x' to the on.push.branches trigger so GitHub Actions fires on maintenance branches (e.g. 1.x, 1.2.x). The release-branches config in ridedott/release-me-action already supports these patterns.